### PR TITLE
feat: update to reusable ci, fix phpunit errors, and update composer with the require section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,41 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        php-versions: ["8.3", "8.4"]
-        drupal-version: ["10.6", "11.3"] 
-
-    name: PHP ${{ matrix.php-versions }} | Drupal ${{ matrix.drupal-version }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Create docker network
-        run: docker network create ci-default
-
-      - name: Start chromedriver
-        run: |-
-          docker run -d \
-            --name chromedriver \
-            --network ci-default \
-            drupalci/webdriver-chromedriver:production \
-            chromedriver --log-path=/dev/null --verbose --allowed-ips= --allowed-origins=*
-
-      - name: PHPUnit tests
-        run: |
-          docker run \
-            --rm \
-            --name drupal \
-            --hostname drupal \
-            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:ro \
-            --env ENABLE_MODULES \
-            --network ci-default \
-           ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
-        env:
-          ENABLE_MODULES: islandora_search_processor
+  islandora-module-ci:
+    uses: digitalutsc/reusable_workflows/.github/workflows/islandora-module-ci.yml@main
+    with:
+      module_name: islandora_search_processor
+      install_chromedriver: true

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,6 @@
     "support": {
         "issues": "https://github.com/digitalutsc/islandora_search_processor/issues",
         "source": "https://github.com/digitalutsc/islandora_search_processor"
-    }
+    },
+    "require": {}
 }

--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -15,7 +15,7 @@ class LoadTest extends BrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * {@inheritdoc}
@@ -43,7 +43,7 @@ class LoadTest extends BrowserTestBase {
    */
   public function testLoad() {
     $this->drupalGet(Url::fromRoute('<front>'));
-    $this->assertSession()->statusMessageContains('200');
+    $this->assertSession()->statusCodeEquals(200);
   }
 
 }

--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -4,12 +4,14 @@ namespace Drupal\Tests\islandora_search_processor\Functional;
 
 use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Simple test to ensure that main page loads with module enabled.
  *
  * @group islandora_search_processor
  */
+#[RunTestsInSeparateProcesses]
 class LoadTest extends BrowserTestBase {
 
   /**


### PR DESCRIPTION
# Description
This PR updates the CI to use a reusable workflow, simplifying the setup and maintenance of the workflow, and fixes the PHPUnit errors.

# Changes
- Replaces the custom `build` job in `.github/workflows/ci.yml` with a call to the `islandora-module-ci` reusable workflow from `digitalutsc/reusable_workflows`, passing in the module name and enabling Chromedriver installation. This removes the explicit matrix, Docker commands, and manual steps, streamlining the workflow configuration.
- Add empty `require` section in the composer file to avoid 'jq` error in the CI.
- Change theme from `stable` to `stark` and assert the status code instead of message in the LoadTest.
- Make tests run in separate processes ([Reference](https://www.drupal.org/node/3548485))